### PR TITLE
rasp pi cond for vol seg graphics perfomance

### DIFF
--- a/skin.titan.helix/1080i/DialogVolumeBar.xml
+++ b/skin.titan.helix/1080i/DialogVolumeBar.xml
@@ -63,7 +63,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p1.png</texture>
-					<visible>IntegerGreaterThan(player.volume,0)</visible>
+					<visible>IntegerGreaterThan(player.volume,0) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -72,7 +72,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p2.png</texture>
-					<visible>IntegerGreaterThan(player.volume,3)</visible>
+					<visible>IntegerGreaterThan(player.volume,3) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -81,7 +81,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p3.png</texture>
-					<visible>IntegerGreaterThan(player.volume,6)</visible>
+					<visible>IntegerGreaterThan(player.volume,6) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -90,7 +90,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p4.png</texture>
-					<visible>IntegerGreaterThan(player.volume,9)</visible>
+					<visible>IntegerGreaterThan(player.volume,9) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -99,7 +99,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p5.png</texture>
-					<visible>IntegerGreaterThan(player.volume,12)</visible>
+					<visible>IntegerGreaterThan(player.volume,12) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -108,7 +108,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p6.png</texture>
-					<visible>IntegerGreaterThan(player.volume,16)</visible>
+					<visible>IntegerGreaterThan(player.volume,16) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -117,7 +117,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p7.png</texture>
-					<visible>IntegerGreaterThan(player.volume,19)</visible>
+					<visible>IntegerGreaterThan(player.volume,19) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -126,7 +126,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p8.png</texture>
-					<visible>IntegerGreaterThan(player.volume,22)</visible>
+					<visible>IntegerGreaterThan(player.volume,22) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -135,7 +135,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p9.png</texture>
-					<visible>IntegerGreaterThan(player.volume,25)</visible>
+					<visible>IntegerGreaterThan(player.volume,25) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -144,7 +144,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p10.png</texture>
-					<visible>IntegerGreaterThan(player.volume,28)</visible>
+					<visible>IntegerGreaterThan(player.volume,28) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -153,7 +153,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p11.png</texture>
-					<visible>IntegerGreaterThan(player.volume,32)</visible>
+					<visible>IntegerGreaterThan(player.volume,32) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -162,7 +162,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p12.png</texture>
-					<visible>IntegerGreaterThan(player.volume,35)</visible>
+					<visible>IntegerGreaterThan(player.volume,35) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -171,7 +171,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p13.png</texture>
-					<visible>IntegerGreaterThan(player.volume,38)</visible>
+					<visible>IntegerGreaterThan(player.volume,38) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -180,7 +180,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p14.png</texture>
-					<visible>IntegerGreaterThan(player.volume,41)</visible>
+					<visible>IntegerGreaterThan(player.volume,41) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -189,7 +189,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p15.png</texture>
-					<visible>IntegerGreaterThan(player.volume,44)</visible>
+					<visible>IntegerGreaterThan(player.volume,44) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -198,7 +198,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p16.png</texture>
-					<visible>IntegerGreaterThan(player.volume,48)</visible>
+					<visible>IntegerGreaterThan(player.volume,48) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -207,7 +207,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p17.png</texture>
-					<visible>IntegerGreaterThan(player.volume,51)</visible>
+					<visible>IntegerGreaterThan(player.volume,51) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -216,7 +216,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p18.png</texture>
-					<visible>IntegerGreaterThan(player.volume,54)</visible>
+					<visible>IntegerGreaterThan(player.volume,54) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -225,7 +225,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p19.png</texture>
-					<visible>IntegerGreaterThan(player.volume,57)</visible>
+					<visible>IntegerGreaterThan(player.volume,57) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -234,7 +234,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p20.png</texture>
-					<visible>IntegerGreaterThan(player.volume,60)</visible>
+					<visible>IntegerGreaterThan(player.volume,60) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -243,7 +243,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p21.png</texture>
-					<visible>IntegerGreaterThan(player.volume,64)</visible>
+					<visible>IntegerGreaterThan(player.volume,64) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -252,7 +252,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p22.png</texture>
-					<visible>IntegerGreaterThan(player.volume,67)</visible>
+					<visible>IntegerGreaterThan(player.volume,67) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -261,7 +261,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p23.png</texture>
-					<visible>IntegerGreaterThan(player.volume,70)</visible>
+					<visible>IntegerGreaterThan(player.volume,70) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -270,7 +270,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p24.png</texture>
-					<visible>IntegerGreaterThan(player.volume,73)</visible>
+					<visible>IntegerGreaterThan(player.volume,73) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -279,7 +279,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p25.png</texture>
-					<visible>IntegerGreaterThan(player.volume,76)</visible>
+					<visible>IntegerGreaterThan(player.volume,76) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -288,7 +288,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p26.png</texture>
-					<visible>IntegerGreaterThan(player.volume,80)</visible>
+					<visible>IntegerGreaterThan(player.volume,80) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -297,7 +297,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p27.png</texture>
-					<visible>IntegerGreaterThan(player.volume,83)</visible>
+					<visible>IntegerGreaterThan(player.volume,83) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -306,7 +306,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p28.png</texture>
-					<visible>IntegerGreaterThan(player.volume,86)</visible>
+					<visible>IntegerGreaterThan(player.volume,86) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -315,7 +315,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p29.png</texture>
-					<visible>IntegerGreaterThan(player.volume,89)</visible>
+					<visible>IntegerGreaterThan(player.volume,89) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -324,7 +324,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p30.png</texture>
-					<visible>IntegerGreaterThan(player.volume,92)</visible>
+					<visible>IntegerGreaterThan(player.volume,92) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -333,7 +333,7 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p31.png</texture>
-					<visible>IntegerGreaterThan(player.volume,96)</visible>
+					<visible>IntegerGreaterThan(player.volume,96) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
 				
 				<control type="image">
@@ -342,8 +342,37 @@
                     <width>380</width>
                     <height>380</height>
                     <texture colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">dialogs/volume/segments/p32.png</texture>
-					<visible>IntegerGreaterThan(player.volume,99)</visible>
+					<visible>IntegerGreaterThan(player.volume,99) + !System.Platform.Linux.RaspberryPi</visible>
                 </control>
+				
+				<control type="label">
+                    <posx>920</posx>
+                    <posy>650</posy>
+                    <height>24</height>
+                    <aligny>center</aligny>
+					<font>Bold38</font>
+                    <label>$INFO[Control.GetLabel(1),, %]</label>
+					<visible>!IntegerGreaterThan(player.volume,99)</visible>
+                    <textcolor>FFFFFFFF</textcolor>
+					<shadowcolor>darkgrey</shadowcolor>
+                </control>
+				
+				<control type="label">
+                    <posx>908</posx>
+                    <posy>650</posy>
+                    <height>24</height>
+                    <aligny>center</aligny>
+					<font>Bold38</font>
+                    <label>$INFO[Control.GetLabel(1),, %]</label>
+					<visible>IntegerGreaterThan(player.volume,99)</visible>
+                    <textcolor>FFFFFFFF</textcolor>
+					<shadowcolor>darkgrey</shadowcolor>
+                </control>
+				
+            <control type="progress" id="1">
+                <info>Player.Volume</info>
+                <animation effect="fade" end="0" condition="true">Conditional</animation>
+            </control>
 				
             </control>
         </control>


### PR DESCRIPTION
In case you wanted to provide code to adjust possible heavy graphic usage in response to 

http://forum.kodi.tv/showthread.php?tid=222364

the current code will disable vol segment graphics on System.Platform.Linux.RaspberryPi to
help improve performance...... this also could be a skin setting instead.

also add percentage text label for vol level (enabled for all platforms,
but could be edited to be enabled only for Rasp Pi's or skin setting option for simple volume dialog)

screenshot of changes (on non-rasp pi hardware)

![2015-04-07_08-31-57](https://cloud.githubusercontent.com/assets/6510026/7026807/d1ef66b4-dd00-11e4-885c-1df0c4b654a5.jpg)

screenshot of changes to disable extra graphics on rasp pi hardware *(or possible skin setting toggle)

![2015-04-07_08-36-35](https://cloud.githubusercontent.com/assets/6510026/7026904/803c649c-dd01-11e4-83ad-120fa6ebdc7e.jpg)



