### PR TITLE
add skin option: weather in video info & OSD

### DIFF
--- a/skin.titan.helix/1080i/DialogFullScreenInfo.xml
+++ b/skin.titan.helix/1080i/DialogFullScreenInfo.xml
@@ -22,6 +22,15 @@
 			<animation effect="slide" start="0,0" end="0,-400" tween="cubic" easing="out" delay="300" time="250" reversible="false" condition="!Window.IsActive(VideoOSD.xml) + !Window.Isactive(DialogSeekBar.xml) + !Skin.HasSetting(LowPerformanceMode)">WindowClose</animation>
 			<include condition="Skin.HasSetting(EnableOSDInfo)">OSDInfoPanel</include>
         </control>
+			<!--Weather on Video Info and OSD-->
+		<control type="group">
+            <visible>!Window.IsActive(filebrowser)</visible>
+			<visible>!Window.IsActive(VideoOSDBookmarks.xml)</visible>
+			<visible>!Window.IsActive(DialogPVRChannelsOSD.xml)</visible>
+			<animation effect="slide" start="0,-400" end="0,0" tween="cubic" easing="out" delay="300" time="250" reversible="false" condition="!Window.IsActive(VideoOSD.xml) + !Window.Isactive(DialogSeekBar.xml) + !Skin.HasSetting(LowPerformanceMode)">WindowOpen</animation>
+			<animation effect="slide" start="0,0" end="0,-400" tween="cubic" easing="out" delay="300" time="250" reversible="false" condition="!Window.IsActive(VideoOSD.xml) + !Window.Isactive(DialogSeekBar.xml) + !Skin.HasSetting(LowPerformanceMode)">WindowClose</animation>
+			<include condition="Skin.HasSetting(ShowWeatherVideoInfoOSD)">WeatherInfoOSD</include>
+        </control>	
 		
     </controls>
 </window>

--- a/skin.titan.helix/1080i/DialogSeekBar.xml
+++ b/skin.titan.helix/1080i/DialogSeekBar.xml
@@ -15,6 +15,7 @@
 			<animation effect="slide" start="0,0" end="0,400" tween="cubic" easing="out" delay="2000" time="250" reversible="false" condition="!Window.IsActive(VideoOSD.xml) + !Window.Isactive(DialogFullScreenInfo.xml) + [Window.IsActive(MusicVisualisation.xml) | Window.IsActive(VideoFullScreen.xml)]">WindowClose</animation>
             <include condition="Skin.HasTheme(classic)">OSDPanelClassic</include>
 			<include condition="!Skin.HasTheme(classic)">OSDPanelModern</include>
+			<include condition="Skin.HasSetting(ShowWeatherVideoInfoOSD)">WeatherInfoOSD</include>
         </control>
 		
 		<!-- large forward and rewind labels -->

--- a/skin.titan.helix/1080i/Includes.xml
+++ b/skin.titan.helix/1080i/Includes.xml
@@ -800,6 +800,52 @@
         </control>
     </include>
 
+	<include name="WeatherInfoOSD">
+        <!-- weather info displayed in video OSD and video info -->
+        <control type="group">
+            <posx>60</posx>
+            <posy>620</posy>
+            <width>128</width>
+            <height>128</height>
+            <visible>Weather.IsFetched + Skin.HasSetting(ShowWeatherVideoInfoOSD)</visible>
+			<include>animation_fade_visible_hidden</include>
+			<animation effect="fade" reversible="false" end="80" time="0" condition="true">Conditional</animation>
+            <!--Current Weather-->
+            <control type="image">
+                <!--Current Weather Icon-->
+                <texture>special://skin/extras/weathericons/$INFO[skin.string(WeatherIconPack)]/$INFO[Window(Weather).Property(Current.FanartCode)].png</texture>
+                <width>128</width>
+                <height>128</height>
+                <aspectratio align="left" aligny="bottom">keep</aspectratio>
+            </control>
+            <control type="label">
+                <!--Current Temp-->
+                <width>128</width>
+                <height>128</height>
+                <posx>136</posx>
+                <posy>0</posy>
+                <font>Bold30</font>
+                <textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
+                <align>left</align>
+                <label>$INFO[Window(Weather).Property(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
+                <visible>Weather.IsFetched</visible>
+				<shadowcolor>$INFO[Skin.String(HeaderTextShadowColor)]</shadowcolor>
+            </control>
+			<!--Current Conditions-->
+			<control type="label">
+                    <width>300</width>
+                    <height>128</height>
+					<posx>0</posx>
+                    <posy>75</posy>
+					<font>Bold30</font>
+					<textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
+					<align>left</align>
+					<label>$INFO[Window(Weather).Property(Current.Condition)]</label>
+                    <visible>Weather.IsFetched</visible>
+					<shadowcolor>$INFO[Skin.String(HeaderTextShadowColor)]</shadowcolor>
+            </control>
+        </control>
+    </include>
     
     <!--Sub Menu-->
     <include name="SubMenuButton">

--- a/skin.titan.helix/1080i/Includes.xml
+++ b/skin.titan.helix/1080i/Includes.xml
@@ -827,7 +827,7 @@
                 <font>Bold30</font>
                 <textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
                 <align>left</align>
-                <label>$INFO[Window(Weather).Property(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
+                <label>$INFO[Window(Weather).Property(Current.Temperature)] $INFO[System.TemperatureUnits]</label>
                 <visible>Weather.IsFetched</visible>
 				<shadowcolor>$INFO[Skin.String(HeaderTextShadowColor)]</shadowcolor>
             </control>

--- a/skin.titan.helix/1080i/Includes.xml
+++ b/skin.titan.helix/1080i/Includes.xml
@@ -803,8 +803,8 @@
 	<include name="WeatherInfoOSD">
         <!-- weather info displayed in video OSD and video info -->
         <control type="group">
-            <posx>60</posx>
-            <posy>620</posy>
+            <posx>50</posx>
+            <posy>660</posy>
             <width>128</width>
             <height>128</height>
             <visible>Weather.IsFetched + Skin.HasSetting(ShowWeatherVideoInfoOSD)</visible>
@@ -820,9 +820,9 @@
             </control>
             <control type="label">
                 <!--Current Temp-->
-                <width>128</width>
+                <width>300</width>
                 <height>128</height>
-                <posx>136</posx>
+                <posx>132</posx>
                 <posy>0</posy>
                 <font>Bold30</font>
                 <textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
@@ -835,9 +835,9 @@
 			<control type="label">
                     <width>300</width>
                     <height>128</height>
-					<posx>0</posx>
-                    <posy>75</posy>
-					<font>Bold30</font>
+					<posx>132</posx>
+                    <posy>32</posy>
+					<font>Reg24</font>
 					<textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
 					<align>left</align>
 					<label>$INFO[Window(Weather).Property(Current.Condition)]</label>
@@ -845,6 +845,21 @@
 					<shadowcolor>$INFO[Skin.String(HeaderTextShadowColor)]</shadowcolor>
             </control>
         </control>
+    </include>
+    
+    <!--Sub Menu-->
+    <include name="SubMenuButton">
+        <!--Sub Menu Button-->
+        <width>458</width>
+        <align>left</align>
+		<font>Reg26</font>
+        <textcolor>$VAR[ThemeFontColorBlack]</textcolor>
+        <focusedcolor>black</focusedcolor>
+        <disabledcolor>77585858</disabledcolor>
+        <pulseonselect>false</pulseonselect>
+        <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">colors/color_white.png</texturefocus>
+        <texturenofocus>-</texturenofocus>
+		
     </include>
     
     <!--Sub Menu-->

--- a/skin.titan.helix/1080i/Includes.xml
+++ b/skin.titan.helix/1080i/Includes.xml
@@ -861,21 +861,6 @@
         <texturenofocus>-</texturenofocus>
 		
     </include>
-    
-    <!--Sub Menu-->
-    <include name="SubMenuButton">
-        <!--Sub Menu Button-->
-        <width>458</width>
-        <align>left</align>
-		<font>Reg26</font>
-        <textcolor>$VAR[ThemeFontColorBlack]</textcolor>
-        <focusedcolor>black</focusedcolor>
-        <disabledcolor>77585858</disabledcolor>
-        <pulseonselect>false</pulseonselect>
-        <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">colors/color_white.png</texturefocus>
-        <texturenofocus>-</texturenofocus>
-		
-    </include>
     <include name="SubMenuTabLeft">
         <!--Sub Menu Tab Left-->
         <control type="group">

--- a/skin.titan.helix/1080i/IncludesDefaultSkinSettings.xml
+++ b/skin.titan.helix/1080i/IncludesDefaultSkinSettings.xml
@@ -41,6 +41,7 @@
 		<onload condition="!Skin.HasSetting(HomeMenuDefaults20)">Skin.SetString(OSDPanelOpacity, 60)</onload>
 		<onload condition="!Skin.HasSetting(HomeMenuDefaults20)">Skin.SetString(GuideRows, 9)</onload>
 		<onload condition="!Skin.HasSetting(HomeMenuDefaults20)">Skin.SetBool(GuideShowInfo)</onload>
+		<onload condition="!Skin.HasSetting(HomeMenuDefaults20)">Skin.SetBool(ShowWeatherVideoInfoOSD)</onload>
 		
 		<!-- default color settings -->
 		<onload condition="!Skin.HasSetting(HomeMenuDefaults20)">Skin.SetString(ViewDetailsFocusShadowColor, black)</onload>

--- a/skin.titan.helix/1080i/SkinSettings.xml
+++ b/skin.titan.helix/1080i/SkinSettings.xml
@@ -1158,6 +1158,18 @@
                     <selected>Skin.HasSetting(OSDLargeSeekingLabel)</selected>
                 </control>
 				
+				<control type="radiobutton" id="13059">
+                    <description></description>
+                    <width>1230</width>
+                    <align>left</align>
+                    <label>31325</label>
+                    <height>50</height>
+                    <focusedcolor>black</focusedcolor>
+                    <font>Reg28</font>
+                    <onclick>Skin.ToggleSetting(ShowWeatherVideoInfoOSD)</onclick>
+                    <selected>Skin.HasSetting(ShowWeatherVideoInfoOSD)</selected>
+                </control>
+				
 				<!-- skin theme -->
 				<control type="label" id="13060">
                     <width>1230</width>

--- a/skin.titan.helix/language/English/strings.po
+++ b/skin.titan.helix/language/English/strings.po
@@ -1306,6 +1306,10 @@ msgctxt "#31324"
 msgid "Use thumbs/icon based layout for favourites dialog instead of text-based"
 msgstr ""
 
+msgctxt "#31325"
+msgid "Show current weather in the video info & video on-screen displays"
+msgstr ""
+
 msgctxt "#31326"
 msgid "Adjust settings for low performance systems"
 msgstr ""


### PR DESCRIPTION
Skin Option: display the current weather in the video info & video
on-screen displays.

a mod I was playing around with - if you like the mod please feel free to alter/merge code or if you don't like - that is ok too :-/ hehe

I wasn't sure if you wanted me to include insegard in any pull requests or not so I only made changes to the helix folder.

I have been testing the code out all day in various forms and this is what I found most pleasing personally.

when I added the weather to the top and/or bottom panels it never looked right so I decided to place it at it's current location.

hope you like it (or the idea of it) :)

cheers!

Mario

PS - Note that this mod displays the CURRENT weather icon (fanart), temp and conditions.

The weather on the skin's Home is the Day0 fanart and not necessarily current conditions.
I found this out when reading up on weather INFO labels,

screenshots of code as is for reference:

![2015-04-10_20-16-45](https://cloud.githubusercontent.com/assets/6510026/7100058/b4d7601a-dfbf-11e4-8934-48651d6eaded.png)
![2015-04-10_20-17-56](https://cloud.githubusercontent.com/assets/6510026/7100059/b4da0838-dfbf-11e4-9c3e-e492c12ffa31.jpg)
![2015-04-10_20-18-48](https://cloud.githubusercontent.com/assets/6510026/7100060/b4db119c-dfbf-11e4-9f7c-96163de5d4c6.jpg)
