### PR TITLE
Weather on Home: Current Weather Conditions Option

### DIFF
--- a/skin.titan.helix/1080i/Home.xml
+++ b/skin.titan.helix/1080i/Home.xml
@@ -57,7 +57,8 @@
 		<control type="group">
 			<include>animation_window_open_close</include>
 			<visible>Window.IsActive(home)</visible>
-			<include>WeatherInfo</include>
+			<include condition="!Skin.HasSetting(WeatherOnHomeShowCurrentCond) + Skin.HasSetting(WeatherOnHome)">WeatherInfo</include>
+			<include condition="Skin.HasSetting(WeatherOnHomeShowCurrentCond) + Skin.HasSetting(WeatherOnHome)">CurrentWeatherInfo</include>
 			<include>ProfileInfo</include>
 					
 			<!-- Kodi Logo image -->

--- a/skin.titan.helix/1080i/Includes.xml
+++ b/skin.titan.helix/1080i/Includes.xml
@@ -808,6 +808,56 @@
             </control>
         </control>
     </include>
+	
+	<include name="CurrentWeatherInfo">
+        <!-- weather info -->
+        <control type="group">
+			<animation effect="slide" end="440" time="0" condition="Skin.String(GadgetRows, simplever)">Conditional</animation>
+            <posx>30</posx>
+            <posy>15</posy>
+            <width>350</width>
+            <height>300</height>
+			<visible>!Control.IsVisible(882)</visible>
+			<visible>!Control.IsVisible(77551)</visible>
+            <visible>Weather.IsFetched</visible>
+			<include>animation_fade_visible_hidden</include>
+            <visible>!Window.IsActive(DialogKaiToast.xml) + !Window.IsActive(DialogExtendedProgressBar.xml) + Skin.HasSetting(WeatherOnHome) + ![ControlGroup(77777).HasFocus | StringCompare(Window(Home).Property(ShowWidget),show)] + !Control.IsVisible(88888)</visible>
+            <!--Weather Today-->
+            <control type="image">
+                <!--Icon-->
+                <texture>special://skin/extras/weathericons/$INFO[skin.string(WeatherIconPack)]/$INFO[Window(Weather).Property(Current.FanartCode)].png</texture>
+                <width>125</width>
+                <height>125</height>
+                <aspectratio align="left" aligny="bottom">keep</aspectratio>
+            </control>
+            <control type="label">
+                <!--Temp-->
+                <width>160</width>
+                <height>40</height>
+                <posx>140</posx>
+                <posy>25</posy>
+                <font>Bold38</font>
+                <textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
+                <align>left</align>
+                <label>$INFO[Window(Weather).Property(Current.Temperature)] $INFO[System.TemperatureUnits]</label>
+                <visible>Weather.IsFetched</visible>
+				<shadowcolor>$INFO[Skin.String(HeaderTextShadowColor)]</shadowcolor>
+            </control>
+            <control type="label">
+                <!--Temp-->
+                <width>220</width>
+                <height>40</height>
+                <posx>140</posx>
+                <posy>70</posy>
+                <font>Reg28</font>
+                <textcolor>$INFO[Skin.String(HeaderTextColor)]</textcolor>
+				<shadowcolor>$INFO[Skin.String(HeaderTextShadowColor)]</shadowcolor>
+                <align>left</align>
+                <label>$INFO[Window(Weather).Property(Current.Condition)]</label>
+                <visible>Weather.IsFetched</visible>
+            </control>
+        </control>
+    </include>
 
 	<include name="WeatherInfoOSD">
         <!-- weather info displayed in video OSD and video info -->

--- a/skin.titan.helix/1080i/SkinSettings.xml
+++ b/skin.titan.helix/1080i/SkinSettings.xml
@@ -1593,6 +1593,18 @@
 					<onclick>Skin.Reset(ShowProfile)</onclick>
                     <selected>Skin.HasSetting(WeatherOnHome)</selected>
                 </control>
+				<control type="radiobutton" id="23027">
+                    <description></description>
+                    <width>1230</width>
+                    <align>left</align>
+                    <label>31446</label>
+                    <height>50</height>
+                    <focusedcolor>black</focusedcolor>
+                    <font>Reg24</font>
+                    <onclick>Skin.ToggleSetting(WeatherOnHomeShowCurrentCond)</onclick>
+                    <selected>Skin.HasSetting(WeatherOnHomeShowCurrentCond)</selected>
+					<visible>Skin.HasSetting(WeatherOnHome)</visible>
+                </control>
 				<control type="radiobutton" id="23022">
                     <description></description>
                     <!--show profile-->

--- a/skin.titan.helix/language/English (US)/strings.po
+++ b/skin.titan.helix/language/English (US)/strings.po
@@ -1471,3 +1471,7 @@ msgstr "Big List"
 msgctxt "#31445"
 msgid "Horizontal Panel"
 msgstr "Horizontal Panel"
+
+msgctxt "#31446"
+msgid "    - Show Current Weather Conditions (instead of Today's Forecast) for Weather on Home"
+msgstr "    - Show Current Weather Conditions (instead of Today's Forecast) for Weather on Home"

--- a/skin.titan.helix/language/English/strings.po
+++ b/skin.titan.helix/language/English/strings.po
@@ -1506,6 +1506,9 @@ msgctxt "#31445"
 msgid "Horizontal Panel"
 msgstr ""
 
+msgctxt "#31446"
+msgid "    - Show Current Weather Conditions (instead of Today's Forecast) for Weather on Home"
+msgstr ""
 
 
 


### PR DESCRIPTION
Option to Show Current Weather Conditions (instead of Today's Forecast)
for Weather on Home

- toggle option is only visible if "weatheronhome" is true.

![2015-04-26_14-22-33](https://cloud.githubusercontent.com/assets/6510026/7339330/d62a7af6-ec1f-11e4-95b4-1da81c686fee.png)
![2015-04-26_14-22-50](https://cloud.githubusercontent.com/assets/6510026/7339331/d62ada28-ec1f-11e4-8c64-876c3eec4075.jpg)

