### PR TITLE
fix skin setting & label for: Use Large Icons in OSD

### DIFF
--- a/skin.titan.helix/1080i/SkinSettings.xml
+++ b/skin.titan.helix/1080i/SkinSettings.xml
@@ -665,7 +665,7 @@
                     <description></description>
                     <width>1230</width>
                     <align>left</align>
-                    <label>31476</label>
+                    <label>31493</label>
                     <height>50</height>
                     <font>Reg28</font>
 					<onclick>Skin.ToggleSetting(OSDUseLargeIcons)</onclick>

--- a/skin.titan.helix/language/English/strings.po
+++ b/skin.titan.helix/language/English/strings.po
@@ -1725,5 +1725,9 @@ msgctxt "#31492"
 msgid "Forced view for episodes"
 msgstr ""
 
+msgctxt "#31493"
+msgid "Use Large Icons in OSD"
+msgstr ""
+
 
 


### PR DESCRIPTION
 fix skin setting & label for: Use Large Icons in OSD 

![2015-06-03_11-54-36](https://cloud.githubusercontent.com/assets/6510026/7969592/c06c6ff4-09ec-11e5-9c0b-70b508648078.png)
