### PR TITLE
fixes for trakt contextmenu dialog

### DIFF
--- a/skin.titan.helix/1080i/script-trakt-ContextMenu.xml
+++ b/skin.titan.helix/1080i/script-trakt-ContextMenu.xml
@@ -1,16 +1,27 @@
 <window>
     <coordinates>
         <system>1</system>
-        <posx>780</posx>
-        <posy>405</posy>
+        <posx>705</posx>
+        <posy>378</posy>
     </coordinates>
 	<controls>
+        <control type="image">
+            <description>Fade</description>
+            <posx>-1050</posx>
+            <posy>-750</posy>
+            <width>3300</width>
+            <height>3300</height>
+            <texture>colors/color_white.png</texture>
+			<animation effect="fade" end="20" time="0" condition="true">Conditional</animation>
+			<colordiffuse>$INFO[Skin.String(ButtonFocusColor)]</colordiffuse>
+        </control>
+		
 		<control type="group">
 			<control type="image">
 				<posx>-10</posx>
 				<posy>-10</posy>
-				<width>360</width>
-				<height>190</height>
+				<width>510</width>
+				<height>330</height>
 				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
 				<texture border="5">diffuse/panel.png</texture>
 				<animation effect="fade" end="40" time="0" condition="true">Conditional</animation>
@@ -20,34 +31,34 @@
 				<description>background image</description>
 				<posx>0</posx>
 				<posy>0</posy>
-				<width>340</width>
-				<height>175</height>
+	            <width>490</width>
+                <height>310</height>
 				<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
-				<texture border="80">colors/color_white.png</texture>
+				<texture border="10">diffuse/panel.png</texture>
 			</control>
 			<control type="list" id="111">
 				<posx>20</posx>
 				<posy>20</posy>
-				<width>300</width>
-				<height>322</height>
+                <width>450</width>
+                <height>483</height>
 				<onup>111</onup>
 				<ondown>111</ondown>
 				<onleft>111</onleft>
 				<onright>111</onright>
 				<scrolltime>200</scrolltime>
-				<itemlayout height="46" width="300">
+				<itemlayout height="70" width="450">
 					<control type="image">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>300</width>
-						<height>40</height>
-						<texture border="5" colordiffuse="$INFO[Skin.String(ButtonColor)]">diffuse/panel_trans.png</texture>
+						<width>450</width>
+						<height>60</height>
+						<texture border="8" colordiffuse="$INFO[Skin.String(ButtonColor)]">diffuse/panel_trans.png</texture>
 					</control>
 					<control type="label">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>300</width>
-						<height>40</height>
+						<width>450</width>
+						<height>60</height>
 						<font>font13</font>
 						<textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
 						<shadowcolor>black</shadowcolor>
@@ -57,13 +68,13 @@
 						<info>ListItem.Label</info>
 					</control>
 				</itemlayout>
-				<focusedlayout height="46" width="300">
+				<focusedlayout height="70" width="450">
 					<control type="image">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>300</width>
-						<height>40</height>
-						<texture border="5" colordiffuse="$INFO[Skin.String(ButtonColor)]">diffuse/panel_trans.png</texture>
+						<width>450</width>
+						<height>60</height>
+						<texture border="8" colordiffuse="$INFO[Skin.String(ButtonColor)]">diffuse/panel_trans.png</texture>
 						<visible>!Control.HasFocus(111)</visible>
 						<animation effect="fade" time="300">Visible</animation>
 						<animation effect="fade" time="300">Hidden</animation>
@@ -71,9 +82,9 @@
 					<control type="image">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>300</width>
-						<height>40</height>
-						<texture diffuse="diffuse/panel.png" border="5" colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">colors/color_white.png</texture>
+						<width>450</width>
+						<height>60</height>
+						<texture border="8" colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">diffuse/panel.png</texture>
 						<visible>Control.HasFocus(111)</visible>
 						<animation effect="fade" time="300">Visible</animation>
 						<animation effect="fade" time="300">Hidden</animation>
@@ -81,14 +92,29 @@
 					<control type="label">
 						<posx>0</posx>
 						<posy>0</posy>
-						<width>300</width>
-						<height>40</height>
+						<width>450</width>
+						<height>60</height>
 						<font>font13</font>
-						<textcolor>$INFO[Skin.String(GeneralTextColor)]</textcolor>
+						<textcolor>$INFO[Skin.String(ButtonTextColor)]</textcolor>
 						<shadowcolor>black</shadowcolor>
 						<selectedcolor>FFFFFF33</selectedcolor>
 						<align>center</align>
 						<aligny>center</aligny>
+						<visible>!Control.HasFocus(111)</visible>
+						<info>ListItem.Label</info>
+					</control>
+					<control type="label">
+						<posx>0</posx>
+						<posy>0</posy>
+						<width>450</width>
+						<height>60</height>
+						<font>font13</font>
+						<textcolor>$INFO[Skin.String(ButtonFocusTextColor)]</textcolor>
+						<shadowcolor>black</shadowcolor>
+						<selectedcolor>FFFFFF33</selectedcolor>
+						<align>center</align>
+						<aligny>center</aligny>
+						<visible>Control.HasFocus(111)</visible>
 						<info>ListItem.Label</info>
 					</control>
 				</focusedlayout>


### PR DESCRIPTION
resized, cleanup and fixes for trakt contextmenu dialog - now follows
skin themed colors properly and uses the new slightly rounded diffused
textures for buttons and background panels.

![2015-06-29_16-08-40](https://cloud.githubusercontent.com/assets/6510026/8420682/0cd812c0-1e7a-11e5-8c23-6b7b7b81523e.png)
