### PR TITLE
add missing panel opacity to nextup dialogs

### DIFF
--- a/skin.titan.helix/1080i/script-nextup-notification-NextUpInfo.xml
+++ b/skin.titan.helix/1080i/script-nextup-notification-NextUpInfo.xml
@@ -29,6 +29,11 @@
 			<width>1280</width>
 			<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
 			<texture border="5">diffuse/panel.png</texture>
+			<animation effect="fade" reversible="false" end="80" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),80)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="60" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),60)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="40" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),40)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="20" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),20)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="0" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),0)">Conditional</animation>
 			</control>
 			
 				<control type="image" id="3009" description="poster">

--- a/skin.titan.helix/1080i/script-nextup-notification-StillWatchingInfo.xml
+++ b/skin.titan.helix/1080i/script-nextup-notification-StillWatchingInfo.xml
@@ -29,6 +29,11 @@
 			<width>1280</width>
 			<colordiffuse>$INFO[Skin.String(GeneralPanelsColor)]</colordiffuse>
 			<texture border="5">diffuse/panel.png</texture>
+			<animation effect="fade" reversible="false" end="80" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),80)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="60" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),60)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="40" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),40)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="20" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),20)">Conditional</animation>
+			<animation effect="fade" reversible="false" end="0" time="0" condition="StringCompare(Skin.String(GeneralPanelsOpacity),0)">Conditional</animation>
 			</control>
 				<!-- -->
 				<control type="image" id="4001"><!-- Poster -->


### PR DESCRIPTION
add missing panel opacity of nextup dialogs to match skin settings.

![2015-07-05_08-01-56](https://cloud.githubusercontent.com/assets/6510026/8512203/6d7169c0-22ed-11e5-8178-b9ca1838ca9c.jpg)
