### PR TITLE
change submenubutton include to follow theme colors

### DIFF
--- a/skin.titan.helix/1080i/Includes.xml
+++ b/skin.titan.helix/1080i/Includes.xml
@@ -928,16 +928,17 @@
     
     <!--Sub Menu-->
     <include name="SubMenuButton">
-        <!--Sub Menu Button-->
-        <width>458</width>
-        <align>left</align>
+		<width>458</width>
+		<align>left</align>
 		<font>Reg26</font>
-        <textcolor>$INFO[Skin.String(FooterTextColor)]</textcolor>
-        <disabledcolor>77585858</disabledcolor>
-        <pulseonselect>false</pulseonselect>
-        <texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]">colors/color_white.png</texturefocus>
-        <texturenofocus>-</texturenofocus>
-		
+		<textcolor>$INFO[Skin.String(ButtonTextColor)]</textcolor>
+		<focusedcolor>$INFO[Skin.String(ButtonFocusTextColor)]</focusedcolor>
+		<shadowcolor>black</shadowcolor>
+		<disabledcolor>77585858</disabledcolor>
+		<invalidcolor>red</invalidcolor>
+		<pulseonselect>false</pulseonselect>
+		<texturefocus colordiffuse="$INFO[Skin.String(ButtonFocusColor)]" border="5">diffuse/panel.png</texturefocus>
+        <texturenofocus colordiffuse="$INFO[Skin.String(ButtonColor)]" border="5">diffuse/panel_trans.png</texturenofocus>
     </include>
     <include name="SubMenuTabLeft">
         <!--Sub Menu Tab Left-->


### PR DESCRIPTION
changes the submenubutton include to follow skin theme colors.

![2015-07-12_21-42-22](https://cloud.githubusercontent.com/assets/6510026/8642815/4b0d4cf8-28df-11e5-824d-4be388711232.jpg)