### PR TITLE
Update xbmc.gui dependency to 5.14.0

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon id="skin.titan" version="3.8.5" name="Titan" provider-name="marcelveldt,mgonzales">
 	<requires>
-		<import version="5.13.0" addon="xbmc.gui"/>		
+		<import version="5.14.0" addon="xbmc.gui"/>		
 		<import addon="script.skinshortcuts" version="0.6.5"/>
 		<import addon="script.skin.helper.service" version="1.0.0"/>
         <import addon="script.skin.helper.widgets" version="1.0.0"/>


### PR DESCRIPTION
Current master branch of Kodi uses xbmc.gui 5.14.0.  A simple update of the version in addons.xml seems to resolve this without introducing any issues, so far as I have encountered.  I am currently running a zip with this modification (which also contains the missing media folder from the 3.8.4 release).